### PR TITLE
Output monitoring

### DIFF
--- a/plugin/include/Pitchblade/PluginProcessor.h
+++ b/plugin/include/Pitchblade/PluginProcessor.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include <memory>
 #include <juce_audio_processors/juce_audio_processors.h>
+#include <JuceHeader.h> // Required for AudioDeviceManager and other utils
 //Austin
 #include "Pitchblade/effects/GainProcessor.h"       
 #include "Pitchblade/effects/CompressorProcessor.h" 
@@ -180,6 +181,45 @@ private:
     
     // JUCE helper that smooths out CPU usage calculation
     juce::AudioProcessLoadMeasurer loadMeasurer;
+
+    //==============================================================================
+    // Standalone Monitoring System
+    //==============================================================================
+    
+    // Internal callback class to handle the secondary device's audio callback
+    class MonitorOutputCallback : public juce::AudioIODeviceCallback {
+    public:
+        MonitorOutputCallback(AudioPluginAudioProcessor& p) : owner(p) {}
+
+        void audioDeviceIOCallbackWithContext(const float* const* inputChannelData,
+            int numInputChannels,
+            float* const* outputChannelData,
+            int numOutputChannels,
+            int numSamples,
+            const juce::AudioIODeviceCallbackContext& context) override;
+
+        void audioDeviceAboutToStart(juce::AudioIODevice* device) override {}
+        void audioDeviceStopped() override {}
+
+    private:
+        AudioPluginAudioProcessor& owner;
+    };
+
+    MonitorOutputCallback monitorCallback { *this };
+
+public:
+    // Standalone-only Monitor Device Manager
+    juce::AudioDeviceManager monitorDeviceManager;
+    
+    // Ring Buffer components
+    juce::AbstractFifo monitorFifo { 48000 }; // 1 second buffer approx
+    juce::AudioBuffer<float> monitorBuffer;
+    
+    std::atomic<float> monitorVolume { 1.0f };
+
+    // Method to set the monitor device by name
+    void setMonitorDevice(const juce::String& deviceName);
+
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (AudioPluginAudioProcessor)
 };

--- a/plugin/include/Pitchblade/panels/SettingsPanel.h
+++ b/plugin/include/Pitchblade/panels/SettingsPanel.h
@@ -28,6 +28,12 @@ private:
 
     juce::TextButton audioSettingsButton { "Audio Settings" };
 
+    // Monitor Device Controls (Standalone Only)
+    juce::Label monitorDeviceLabel;
+    juce::ComboBox monitorDeviceSelector;
+    juce::Label monitorGainLabel;
+    juce::Slider monitorGainSlider;
+
     //TextEditor to hold the license info
     juce::TextEditor licenseText;
 

--- a/plugin/source/PluginProcessor.cpp
+++ b/plugin/source/PluginProcessor.cpp
@@ -158,10 +158,25 @@ AudioPluginAudioProcessor::AudioPluginAudioProcessor()
     
     // Add listener to the main state (or specifically the chain)
     apvts.state.addListener(this);
+
+    // Initialize Monitor Buffer
+    monitorBuffer.setSize(2, 48000);
+    monitorBuffer.clear();
+
+    // Initialize Monitor Device Manager (if Standalone) - scans for devices
+    if (juce::JUCEApplication::isStandaloneApp()) {
+        monitorDeviceManager.initialise(0, 2, nullptr, true);
+        monitorDeviceManager.addAudioCallback(&monitorCallback);
+    }
 }
 
 // Destructor: ensures processor is suspended when the its deleted
-AudioPluginAudioProcessor::~AudioPluginAudioProcessor(){ suspendProcessing(true); }
+AudioPluginAudioProcessor::~AudioPluginAudioProcessor(){ 
+    if (juce::JUCEApplication::isStandaloneApp()) {
+        monitorDeviceManager.removeAudioCallback(&monitorCallback);
+    }
+    suspendProcessing(true); 
+}
 
 //============================================================================== reyna
 // global APVTS parameter layout
@@ -497,7 +512,40 @@ void AudioPluginAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, 
         buffer.clear(i, 0, buffer.getNumSamples());
     }
 
-    
+    // ============================================================
+    // Standalone Monitor Output Logic
+    // ============================================================
+    if (juce::JUCEApplication::isStandaloneApp() && monitorDeviceManager.getCurrentAudioDevice() != nullptr) {
+        // 1. Get Mixed Stereo Signal (taking main L/R)
+        // We assume Main Output is channels 0 and 1.
+        if (buffer.getNumChannels() >= 2) {
+            float rawVol = monitorVolume.load();
+            float vol = rawVol * rawVol; // Quadratic taper for balanced feels
+            int numSamples = buffer.getNumSamples();
+
+            // Prepare to write to FIFO
+            // We want to write 'numSamples' into the ring buffer
+            int start1, size1, start2, size2;
+            monitorFifo.prepareToWrite(numSamples, start1, size1, start2, size2);
+            
+
+
+            if (size1 > 0) {
+                for (int ch = 0; ch < 2; ++ch) {
+                    // Copy and Apply Volume
+                    monitorBuffer.copyFrom(ch, start1, buffer, ch, 0, size1);
+                    monitorBuffer.applyGain(ch, start1, size1, vol);
+                }
+            }
+            if (size2 > 0) {
+                for (int ch = 0; ch < 2; ++ch) {
+                    monitorBuffer.copyFrom(ch, start2, buffer, ch, size1, size2);
+                    monitorBuffer.applyGain(ch, start2, size2, vol);
+                }
+            }
+            monitorFifo.finishedWrite(size1 + size2);
+        }
+    }
 }
 
 //==============================================================================
@@ -760,4 +808,94 @@ void AudioPluginAudioProcessor::valueTreePropertyChanged(juce::ValueTree& tree, 
         syncChainFromState();
         triggerUIRebuild();
     }
+}
+
+
+//==============================================================================
+// Standalone Monitor Implementation
+//==============================================================================
+
+void AudioPluginAudioProcessor::MonitorOutputCallback::audioDeviceIOCallbackWithContext(
+    const float* const* inputChannelData,
+    int numInputChannels,
+    float* const* outputChannelData,
+    int numOutputChannels,
+    int numSamples,
+    const juce::AudioIODeviceCallbackContext& context)
+{
+    juce::ignoreUnused(inputChannelData, numInputChannels, context);
+    
+    // Safety check
+    if (numOutputChannels == 0 || outputChannelData == nullptr) return;
+
+    // Clear buffer first
+    for (int i = 0; i < numOutputChannels; ++i)
+        if (outputChannelData[i])
+            juce::FloatVectorOperations::clear(outputChannelData[i], numSamples);
+
+    // Read from FIFO
+    int start1, size1, start2, size2;
+    owner.monitorFifo.prepareToRead(numSamples, start1, size1, start2, size2);
+
+    // If we don't have enough data (Underrun), simply output silence (already cleared)
+    // and DO NOT advance read pointer. Or we could advance up to available?
+    // Standard ring buffer logic: if empty, play silence.
+    int totalAvailable = size1 + size2;
+    
+    if (totalAvailable < numSamples) {
+        // Buffer Underrun - Just play silence (we already cleared output)
+
+        return; 
+    }
+
+    // Read Logic
+    if (size1 > 0) {
+        for (int i = 0; i < juce::jmin(2, numOutputChannels); ++i) {
+             juce::FloatVectorOperations::copy(outputChannelData[i], 
+                                             owner.monitorBuffer.getReadPointer(i, start1),
+                                             size1);
+        }
+    }
+    if (size2 > 0) {
+        for (int i = 0; i < juce::jmin(2, numOutputChannels); ++i) {
+              // Offset output ptr by size1
+             juce::FloatVectorOperations::copy(outputChannelData[i] + size1, 
+                                             owner.monitorBuffer.getReadPointer(i, start2),
+                                             size2);
+        }
+    }
+
+    owner.monitorFifo.finishedRead(size1 + size2);
+}
+
+void AudioPluginAudioProcessor::setMonitorDevice(const juce::String& deviceName) {
+    if (deviceName.isEmpty()) {
+        monitorDeviceManager.closeAudioDevice();
+        return;
+    }
+
+    // Check if it's already current
+    auto* current = monitorDeviceManager.getCurrentAudioDevice();
+    if (current && current->getName() == deviceName) return;
+
+    // Initialize with specific device
+    // We want 0 inputs, 2 outputs.
+    // NOTE: This usually needs to be done on Message Thread. This function is called from UI, so it is safe.
+    juce::AudioDeviceManager::AudioDeviceSetup setup;
+    monitorDeviceManager.getAudioDeviceSetup(setup);
+    
+    setup.outputDeviceName = deviceName;
+    setup.inputDeviceName = ""; // No input for monitor
+    setup.useDefaultInputChannels = false;
+    setup.useDefaultOutputChannels = true;
+    
+    // Try to init
+    // initialise(numInputChannelsNeeded, numOutputChannelsNeeded, savedStateXml, selectDefaultDeviceOnFailure, preferredDefaultDeviceName, preferredSetupOptions)
+    // We use setAudioDeviceSetup which is cleaner for switching
+    
+    // monitorDeviceManager.setAudioDeviceSetup(setup, true);
+    juce::String err = monitorDeviceManager.setAudioDeviceSetup(setup, true);
+    
+    // reset fifo just in case
+    monitorFifo.reset();
 }

--- a/plugin/source/panels/SettingsPanel.cpp
+++ b/plugin/source/panels/SettingsPanel.cpp
@@ -37,6 +37,74 @@ SettingsPanel::SettingsPanel(AudioPluginAudioProcessor& p) : processor(p) {
         #endif
     };
 
+    // Monitor Device Configuration (Standalone Only)
+    if (juce::JUCEApplication::isStandaloneApp()) {
+        
+        // 1. Device Selector
+        addAndMakeVisible(monitorDeviceLabel);
+        monitorDeviceLabel.setText("Monitor Output:", juce::dontSendNotification);
+        monitorDeviceLabel.setJustificationType(juce::Justification::centredLeft);
+        monitorDeviceLabel.setColour(juce::Label::textColourId, Colors::buttonText);
+
+        addAndMakeVisible(monitorDeviceSelector);
+        
+        // Populate Device List
+        // Note: In real setup, we might need to refresh this. For now, init once.
+        const auto& deviceTypes = processor.monitorDeviceManager.getAvailableDeviceTypes();
+        int itemId = 1;
+        
+        // Add "None" option
+        monitorDeviceSelector.addItem("None", itemId++);
+
+        for (auto* type : deviceTypes) {
+            auto devices = type->getDeviceNames(); 
+            for (const auto& deviceName : devices) {
+                // Skip if it looks like an input-only device? 
+                // device names are just strings. 
+                monitorDeviceSelector.addItem(deviceName + " (" + type->getTypeName() + ")", itemId++);
+            }
+        }
+        
+        // Restore selection if possible (would need saved state, skipping for now)
+        monitorDeviceSelector.onChange = [this] {
+            // Parse name from text or maintain a map. Simplest is text for now.
+            // Items format: "DeviceName (TypeName)"
+            // Use ID to map back? Or just pass full text?
+            // Since we stored name+type, we need to extract name or just pass name if it's unique enough.
+            // Let's assume for this MVP we just pass the raw "Device Name" part.
+            // Actually, setMonitorDevice expects exact name for `outputDeviceName`.
+            
+            auto text = monitorDeviceSelector.getText();
+            if (text == "None") {
+                 processor.setMonitorDevice("");
+                 return;
+            }
+
+            // quick hack to strip (Type)
+            int bracket = text.lastIndexOf("(");
+            if (bracket > 0) {
+                auto name = text.substring(0, bracket).trim();
+                processor.setMonitorDevice(name);
+            }
+        };
+
+        // 2. Volume Slider
+        addAndMakeVisible(monitorGainLabel);
+        monitorGainLabel.setText("Monitor Vol:", juce::dontSendNotification);
+        monitorGainLabel.setJustificationType(juce::Justification::centredLeft);
+        monitorGainLabel.setColour(juce::Label::textColourId, Colors::buttonText);
+
+        addAndMakeVisible(monitorGainSlider);
+        monitorGainSlider.setSliderStyle(juce::Slider::LinearHorizontal);
+        monitorGainSlider.setTextBoxStyle(juce::Slider::TextBoxLeft, false, 50, 20);
+        monitorGainSlider.setRange(0.0, 1.0, 0.01);
+        monitorGainSlider.setValue(processor.monitorVolume.load());
+        
+        monitorGainSlider.onValueChange = [this] {
+            processor.monitorVolume.store((float)monitorGainSlider.getValue());
+        };
+    }
+
     //License stuff
     addAndMakeVisible(licenseText);
     licenseText.setMultiLine(true);
@@ -102,6 +170,21 @@ void SettingsPanel::resized(){
         audioSettingsButton.setBounds(area.removeFromTop(40).reduced(20, 0));
 
         area.removeFromTop(10); 
+        
+        // Monitor Device UI
+        auto monitorArea = area.removeFromTop(40).reduced(20, 0);
+        monitorDeviceLabel.setBounds(monitorArea.removeFromLeft(monitorArea.getWidth() / 3));
+        monitorArea.removeFromLeft(10);
+        monitorDeviceSelector.setBounds(monitorArea);
+        
+        area.removeFromTop(5);
+
+        auto monitorVolArea = area.removeFromTop(40).reduced(20, 0);
+        monitorGainLabel.setBounds(monitorVolArea.removeFromLeft(monitorVolArea.getWidth() / 3));
+        monitorVolArea.removeFromLeft(10);
+        monitorGainSlider.setBounds(monitorVolArea);
+
+        area.removeFromTop(10);
     }
 
     auto framerateArea = area.removeFromTop(40).reduced(20,0);


### PR DESCRIPTION
In the standalone, you are now able to set a second output device with its own volume slider. This second output has lower priority, and its main purpose is to monitor audio as it's being sent to the primary output device.